### PR TITLE
Ignore __pycache__ that gets created below ./components/axp192/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
 
 .DS_Store
 .vscode


### PR DESCRIPTION
Happens when this component is included as local external component.

Ref: https://esphome.io/components/external_components.html#local